### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # zeldaGame
 Progress on a throwback Zelda clone with Pygame. Move with arrow keys, transform into wolf with w key, pickup items by walking over them, drop equipped weapon with spacebar.
-
+[![Run on Repl.it](https://repl.it/badge/github/UzayAnil/zeldaGame)](https://repl.it/github/UzayAnil/zeldaGame)
 > $ pip3 install -r requirements.txt
 
 > $ python3 main.py


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).